### PR TITLE
Fix problems with ddev e2e test and minor cleanup, add tmate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - v2
-      - 20220107-ulysses-e2e-ddev
+      - 20220116_ulysses-e2e-ddev_parallel
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,13 @@ on:
   push:
     branches:
       - v2
-      - 20220116_ulysses-e2e-ddev_parallel
   pull_request:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'To run with tmate enter "debug_enabled"'
         required: false
-        default: false
+        default: "false"
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,11 @@ jobs:
           path: ~/go/pkg/mod
           key: go-${{ hashFiles('**/go.sum') }}
 
+      - name: Build for local E2E
+        env:
+          BUILD_TAGS: e2e
+        run: make GIT_TAG=e2e-PR-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }} -f builder.Makefile compose-plugin
+
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:
@@ -134,10 +139,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
-      - name: Build for local E2E
-        env:
-          BUILD_TAGS: e2e
-        run: make GIT_TAG=e2e-PR-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }} -f builder.Makefile compose-plugin
 
       - name: E2E Test in standalone mode
         run: make e2e-compose-standalone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches:
       - v2
+      - 20220107-ulysses-e2e-ddev
   pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate set "debug_enabled"'
+        required: false
+        default: false
 
 jobs:
   lint:
@@ -119,6 +126,13 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-${{ hashFiles('**/go.sum') }}
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
       - name: Build for local E2E
         env:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2
 	rm -f /usr/local/bin/docker-compose
 	cp bin/docker-compose /usr/local/bin
 	docker-compose version
-	go test $(TEST_FLAGS) -count=1 --tags=standalone ./pkg/e2e
+	go test $(TEST_FLAGS) -v -count=1 -parallel=1 --tags=standalone ./pkg/e2e
 
 
 .PHONY: e2e

--- a/pkg/e2e/ddev_test.go
+++ b/pkg/e2e/ddev_test.go
@@ -85,8 +85,10 @@ func TestComposeRunDdev(t *testing.T) {
 
 	c.RunCmdInDir(dir, "./ddev", "poweroff")
 
-	startRes := c.RunCmdInDir(dir, "./ddev", "start", "-y")
-	assert.Equal(c.test, startRes.ExitCode, 0, "Could not start project")
+	c.RunCmdInDir(dir, "./ddev", "start", "-y")
+
+	// This assertion is irrelevant because c.RunCmdInDir() does its own assertion.
+	//assert.Equal(c.test, startRes.ExitCode, 0, "Could not start project")
 
 	curlRes := c.RunCmdInDir(dir, "curl", "-sSL", fmt.Sprintf("http://%s.ddev.site", siteName))
 	out := curlRes.Stdout()

--- a/pkg/e2e/ddev_test.go
+++ b/pkg/e2e/ddev_test.go
@@ -80,6 +80,10 @@ func TestComposeRunDdev(t *testing.T) {
 	// Create a simple index.php we can test against.
 	c.RunCmdInDir(dir, "sh", "-c", "echo '<?php\nprint \"ddev is working\";' >index.php")
 
+	vRes := c.RunCmdInDir(dir, "./ddev", "version")
+	out := vRes.Stdout()
+	fmt.Printf("ddev version: %s\n", out)
+
 	c.RunCmdInDir(dir, "./ddev", "config", "--auto")
 	c.RunCmdInDir(dir, "./ddev", "config", "global", "--use-docker-compose-from-path")
 
@@ -91,7 +95,7 @@ func TestComposeRunDdev(t *testing.T) {
 	//assert.Equal(c.test, startRes.ExitCode, 0, "Could not start project")
 
 	curlRes := c.RunCmdInDir(dir, "curl", "-sSL", fmt.Sprintf("http://%s.ddev.site", siteName))
-	out := curlRes.Stdout()
+	out = curlRes.Stdout()
 	fmt.Println(out)
 	assert.Assert(c.test, strings.Contains(out, "ddev is working"), "Could not start project")
 }

--- a/pkg/e2e/ddev_test.go
+++ b/pkg/e2e/ddev_test.go
@@ -80,12 +80,11 @@ func TestComposeRunDdev(t *testing.T) {
 	// Create a simple index.php we can test against.
 	c.RunCmdInDir(dir, "sh", "-c", "echo '<?php\nprint \"ddev is working\";' >index.php")
 
+	c.RunCmdInDir(dir, "./ddev", "config", "--auto")
+	c.RunCmdInDir(dir, "./ddev", "config", "global", "--use-docker-compose-from-path")
 	vRes := c.RunCmdInDir(dir, "./ddev", "version")
 	out := vRes.Stdout()
 	fmt.Printf("ddev version: %s\n", out)
-
-	c.RunCmdInDir(dir, "./ddev", "config", "--auto")
-	c.RunCmdInDir(dir, "./ddev", "config", "global", "--use-docker-compose-from-path")
 
 	c.RunCmdInDir(dir, "./ddev", "poweroff")
 


### PR DESCRIPTION
This PR makes the ddev e2e test work.

* The key issue is that mkcert is required and is installed by all the standard installation techniques, and of course here we've skipped that. So this adds mkcert and puts it into the $PATH. (I had no idea you could get a fatal on `ddev start` if it didn't exist, but will fix that.)
* This also makes the tests run sequentially, so you can see what's going on in the logs. Without that it's pretty much impossible to sort out what's going on.
* Added [tmate](https://github.com/marketplace/actions/debugging-with-tmate) to the github action so you can ssh into the build and figure out what's going on. It's really nice. You manually start it on the actions page, select the branch you want to test, then it gives you an ssh command line to ssh in.  You may not be able to use this until it gets into the default branch, not sure. 
* I commented out a redundant assertion with an explanation with why (it never gets there)
* I added a `ddev version` command so we can verify that we're using the docker-compose we hope to be testing. (It shows that we are). 

You obviously can use whichever of these you like. The key fix is the installation and initialization of mkcert. 